### PR TITLE
Add unit tests for ch.dvbern.lib.cryptutil.readers

### DIFF
--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityCertReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityCertReaderTest.java
@@ -1,0 +1,25 @@
+package ch.dvbern.lib.cryptutil.readers;
+
+import java.security.interfaces.RSAPublicKey;
+import java.security.PublicKey;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+import static ch.dvbern.lib.cryptutil.TestingUtil.resourceURL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IdentityCertReaderTest {
+
+  @Test
+  public void test_readPublicKey() throws IOException {
+    final URL publicKeyURL = resourceURL("signing/testkey-nopass.pub");
+    final RSAPublicKey rsaKey = new PKCS8PEMCertReader(publicKeyURL.openStream()).readPublicKey();
+    
+    final PublicKey key = new IdentityCertReader(rsaKey).readPublicKey();
+    assertEquals("RSA", key.getAlgorithm());
+    assertEquals("X.509", key.getFormat());
+  }
+}
+

--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityKeyReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityKeyReaderTest.java
@@ -1,0 +1,25 @@
+package ch.dvbern.lib.cryptutil.readers;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.PrivateKey;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+import static ch.dvbern.lib.cryptutil.TestingUtil.resourceURL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IdentityKeyReaderTest {
+
+  @Test
+  public void test_readPrivateKey() throws IOException {
+    final URL privateKeyURL = resourceURL("signing/testkey-nopass-pkcs8.pem");
+    final RSAPrivateKey rsaKey = new PKCS8PEMKeyReader(privateKeyURL.openStream(), null).readPrivateKey();
+    
+    final PrivateKey key = new IdentityKeyReader(rsaKey).readPrivateKey();
+    assertEquals("RSA", key.getAlgorithm());
+    assertEquals("PKCS#8", key.getFormat());
+  }
+}
+

--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMCertReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMCertReaderTest.java
@@ -1,0 +1,32 @@
+package ch.dvbern.lib.cryptutil.readers;
+
+import java.security.interfaces.RSAPublicKey;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+import static ch.dvbern.lib.cryptutil.TestingUtil.resourceURL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PKCS8PEMCertReaderTest {
+
+  @Test
+  public void test_readPublicKey() throws IOException {
+    final URL publicKeyURL = resourceURL("signing/testkey-nopass.pub");
+
+    final RSAPublicKey key = new PKCS8PEMCertReader(publicKeyURL.openStream()).readPublicKey();
+    assertEquals("RSA", key.getAlgorithm());
+    assertEquals("X.509", key.getFormat());
+  }
+
+  @Test
+  public void test_readPublicKeyInvalidPassword() throws IOException {
+    final URL publicKeyURL = resourceURL("signing/testkey-nopass.pem");
+    
+    final ReaderException thrown = 
+      assertThrows(ReaderException.class, () -> new PKCS8PEMCertReader(publicKeyURL.openStream()).readPublicKey());
+    assertEquals("Could not read PKCS8EncodedPEM", thrown.getMessage());
+  }
+}
+

--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMKeyReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMKeyReaderTest.java
@@ -1,0 +1,32 @@
+package ch.dvbern.lib.cryptutil.readers;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+import static ch.dvbern.lib.cryptutil.TestingUtil.resourceURL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PKCS8PEMKeyReaderTest {
+
+  @Test
+  public void test_readPrivateKey() throws IOException {
+    final URL privateKeyURL = resourceURL("signing/testkey-nopass-pkcs8.pem");
+
+    final RSAPrivateKey key = new PKCS8PEMKeyReader(privateKeyURL.openStream(), null).readPrivateKey();
+    assertEquals("RSA", key.getAlgorithm());
+    assertEquals("PKCS#8", key.getFormat());
+  }
+
+  @Test
+  public void test_readPrivateKeyInvalidPassword() throws IOException {
+    final URL privateKeyURL = resourceURL("signing/testkey-nopass-pkcs8.pem");
+    
+    final ReaderException thrown = 
+      assertThrows(ReaderException.class, () -> new PKCS8PEMKeyReader(privateKeyURL.openStream(), "foo").readPrivateKey());
+    assertEquals("Could not read PKCS8EncodedPEM", thrown.getMessage());
+  }
+}
+


### PR DESCRIPTION
Hi, 

I've ran your repository through the [JaCoCo](https://www.jacoco.org/jacoco/) code coverage tool, which reported that you had `63.1%` line coverage from your existing unit tests. 

From this, we have written some sample tests with the help of [Diffblue Cover](https://www.diffblue.com/opensource), for the following previously-uncovered classes:

- `ch.dvbern.lib.cryptutil.readers.IdentityCertReader`
- `ch.dvbern.lib.cryptutil.readers.IdentityKeyReader`
- `ch.dvbern.lib.cryptutil.readers.PKCS8PEMCertReader`
- `ch.dvbern.lib.cryptutil.readers.PKCS8PEMKeyReader`

This now brings your total coverage to `78.5%`.

Hopefully, these tests will help you detect any regressions caused by future code changes. We would be grateful for any feedback you have regarding the quality of these tests.