### PR TITLE
Fix for PR #1 - Close private/public key Input Streams after use

### DIFF
--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityCertReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityCertReaderTest.java
@@ -1,5 +1,6 @@
 package ch.dvbern.lib.cryptutil.readers;
 
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.security.PublicKey;
@@ -15,10 +16,11 @@ public class IdentityCertReaderTest {
 	@Test
 	public void test_readPublicKey() throws IOException {
 		final URL publicKeyURL = resourceURL("signing/testkey-nopass.pub");
-		final RSAPublicKey rsaKey = new PKCS8PEMCertReader(publicKeyURL.openStream()).readPublicKey();
+		final InputStream publicKey = publicKeyURL.openStream();
+		final RSAPublicKey rsaKey = new PKCS8PEMCertReader(publicKey).readPublicKey();
+		publicKey.close();
 
 		final PublicKey key = new IdentityCertReader(rsaKey).readPublicKey();
-
 		assertEquals("RSA", key.getAlgorithm());
 		assertEquals("X.509", key.getFormat());
 	}

--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityKeyReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/IdentityKeyReaderTest.java
@@ -1,5 +1,6 @@
 package ch.dvbern.lib.cryptutil.readers;
 
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.security.PrivateKey;
@@ -15,10 +16,11 @@ public class IdentityKeyReaderTest {
 	@Test
 	public void test_readPrivateKey() throws IOException {
 		final URL privateKeyURL = resourceURL("signing/testkey-nopass-pkcs8.pem");
-		final RSAPrivateKey rsaKey = new PKCS8PEMKeyReader(privateKeyURL.openStream(), null).readPrivateKey();
+		final InputStream privateKey = privateKeyURL.openStream();
+		final RSAPrivateKey rsaKey = new PKCS8PEMKeyReader(privateKey, null).readPrivateKey();
+		privateKey.close();
 
 		final PrivateKey key = new IdentityKeyReader(rsaKey).readPrivateKey();
-
 		assertEquals("RSA", key.getAlgorithm());
 		assertEquals("PKCS#8", key.getFormat());
 	}

--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMCertReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMCertReaderTest.java
@@ -1,5 +1,6 @@
 package ch.dvbern.lib.cryptutil.readers;
 
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.security.interfaces.RSAPublicKey;
@@ -15,22 +16,24 @@ public class PKCS8PEMCertReaderTest {
 	@Test
 	public void test_readPublicKey() throws IOException {
 		final URL publicKeyURL = resourceURL("signing/testkey-nopass.pub");
-
-		final RSAPublicKey key = new PKCS8PEMCertReader(publicKeyURL.openStream()).readPublicKey();
+		final InputStream publicKey = publicKeyURL.openStream();
+		final RSAPublicKey key = new PKCS8PEMCertReader(publicKey).readPublicKey();
+		publicKey.close();
 
 		assertEquals("RSA", key.getAlgorithm());
 		assertEquals("X.509", key.getFormat());
 	}
 
 	@Test
-	public void test_readPublicKeyInvalidPassword() {
+	public void test_readPublicKeyInvalidPassword() throws IOException {
 		final URL publicKeyURL = resourceURL("signing/testkey-nopass.pem");
-
+		final InputStream publicKey = publicKeyURL.openStream();
 		final ReaderException thrown = assertThrows(
 				ReaderException.class,
-				() -> new PKCS8PEMCertReader(publicKeyURL.openStream()).readPublicKey());
+				() -> new PKCS8PEMCertReader(publicKey).readPublicKey());
 
 		assertEquals("Could not read PKCS8EncodedPEM", thrown.getMessage());
+		publicKey.close();
 	}
 }
 

--- a/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMKeyReaderTest.java
+++ b/src/test/java/ch/dvbern/lib/cryptutil/readers/PKCS8PEMKeyReaderTest.java
@@ -1,5 +1,6 @@
 package ch.dvbern.lib.cryptutil.readers;
 
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.security.interfaces.RSAPrivateKey;
@@ -15,22 +16,24 @@ public class PKCS8PEMKeyReaderTest {
 	@Test
 	public void test_readPrivateKey() throws IOException {
 		final URL privateKeyURL = resourceURL("signing/testkey-nopass-pkcs8.pem");
-
-		final RSAPrivateKey key = new PKCS8PEMKeyReader(privateKeyURL.openStream(), null).readPrivateKey();
+		final InputStream privateKey = privateKeyURL.openStream();
+		final RSAPrivateKey key = new PKCS8PEMKeyReader(privateKey, null).readPrivateKey();
+		privateKey.close();
 
 		assertEquals("RSA", key.getAlgorithm());
 		assertEquals("PKCS#8", key.getFormat());
 	}
 
 	@Test
-	public void test_readPrivateKeyInvalidPassword() {
+	public void test_readPrivateKeyInvalidPassword() throws IOException {
 		final URL privateKeyURL = resourceURL("signing/testkey-nopass-pkcs8.pem");
-
+		final InputStream privateKey = privateKeyURL.openStream();
 		final ReaderException thrown = assertThrows(
 				ReaderException.class,
-				() -> new PKCS8PEMKeyReader(privateKeyURL.openStream(), "foo".toCharArray()).readPrivateKey());
+				() -> new PKCS8PEMKeyReader(privateKey, "foo".toCharArray()).readPrivateKey());
 
 		assertEquals("Could not read PKCS8EncodedPEM", thrown.getMessage());
+		privateKey.close();
 	}
 }
 


### PR DESCRIPTION
This is an enhancement to https://github.com/dvbern/cryptutil/pull/1, which closes the `InputStreams` after they have been read.